### PR TITLE
Remove EmailAddress annotation to let steam & kongregate accounts work

### DIFF
--- a/Data/Account.cs
+++ b/Data/Account.cs
@@ -7,7 +7,6 @@ namespace MDTadusMod.Data
         public Guid Id { get; set; }
 
         [Required]
-        [EmailAddress]
         public string Email { get; set; }
 
         [Required]


### PR DESCRIPTION
MDTMod already supports steam accounts when scanning them, but the field requires the input to have email address formatting